### PR TITLE
Add example for request id logging

### DIFF
--- a/examples/express-ts/README.md
+++ b/examples/express-ts/README.md
@@ -17,8 +17,11 @@ $ curl localhost:3000 -H X-Id:1 && curl localhost:3000 -H X-Id:2 && curl localho
 ```
 **Output**
 ```
-X-Id received in the middleware: 1
-X-Id received in the middleware: 2
-X-Id received in the middleware: 3
+[ INFO ] [ 4456b3a2-5362-4302-9897-e0be27e6a6c6 ] X-Id received in the middleware: 1
+[ INFO ] [ 3da70b7d-d580-46f3-9768-76bdb40fb827 ] X-Id received in the middleware: 2
+[ INFO ] [ 480d1b23-fdd4-4d26-92ed-7258d258bf4f ] X-Id received in the middleware: 3
+[ INFO ] [ 4456b3a2-5362-4302-9897-e0be27e6a6c6 ] Request context: 1
+[ INFO ] [ 3da70b7d-d580-46f3-9768-76bdb40fb827 ] Request context: 2
+[ INFO ] [ 480d1b23-fdd4-4d26-92ed-7258d258bf4f ] Request context: 3
 
 ```

--- a/examples/express-ts/README.md
+++ b/examples/express-ts/README.md
@@ -17,17 +17,20 @@ $ curl 'http://localhost:3000?a=20&b=30' && curl 'http://localhost:3000?a=10&b=5
 ```
 **Output**
 ```
-[ DEBUG ] [ 445ef6fb ] Received a: 20
-[ DEBUG ] [ 445ef6fb ] Received b: 30
-[ INFO ] [ 445ef6fb ] Simulating Delay
-[ DEBUG ] [ 445ef6fb ] Calculated sum: 50
-[ DEBUG ] [ b4c27a00 ] Received a: 10
-[ DEBUG ] [ b4c27a00 ] Received b: 50
-[ INFO ] [ b4c27a00 ] Simulating Delay
-[ DEBUG ] [ b4c27a00 ] Calculated sum: 60
-[ DEBUG ] [ a24d4281 ] Received a: 50
-[ DEBUG ] [ a24d4281 ] Received b: 100
-[ INFO ] [ a24d4281 ] Simulating Delay
-[ DEBUG ] [ a24d4281 ] Calculated sum: 150
+[ DEBUG ] [ 006a0e32 ] Received a: 20
+[ DEBUG ] [ 006a0e32 ] Received b: 30
+[ INFO ] [ 006a0e32 ] Simulating Delay
+[ DEBUG ] [ 006a0e32 ] Calculated sum: 50
+[ DEBUG ] [ 0ffd1142 ] Received a: 10
+[ DEBUG ] [ 0ffd1142 ] Received b: 50
+[ INFO ] [ 0ffd1142 ] Simulating Delay
+[ DEBUG ] [ 0ffd1142 ] Calculated sum: 60
+[ DEBUG ] [ 2fa186b9 ] Received a: 50
+[ DEBUG ] [ 2fa186b9 ] Received b: 100
+[ INFO ] [ 2fa186b9 ] Simulating Delay
+[ DEBUG ] [ 2fa186b9 ] Calculated sum: 150
+[ INFO ] [ 006a0e32 ] Delay end.
+[ INFO ] [ 0ffd1142 ] Delay end.
+[ INFO ] [ 2fa186b9 ] Delay end.
 
 ```

--- a/examples/express-ts/README.md
+++ b/examples/express-ts/README.md
@@ -17,20 +17,20 @@ $ curl 'http://localhost:3000?a=20&b=30' && curl 'http://localhost:3000?a=10&b=5
 ```
 **Output**
 ```
-[ DEBUG ] [ 006a0e32 ] Received a: 20
-[ DEBUG ] [ 006a0e32 ] Received b: 30
-[ INFO ] [ 006a0e32 ] Simulating Delay
-[ DEBUG ] [ 006a0e32 ] Calculated sum: 50
-[ DEBUG ] [ 0ffd1142 ] Received a: 10
-[ DEBUG ] [ 0ffd1142 ] Received b: 50
-[ INFO ] [ 0ffd1142 ] Simulating Delay
-[ DEBUG ] [ 0ffd1142 ] Calculated sum: 60
-[ DEBUG ] [ 2fa186b9 ] Received a: 50
-[ DEBUG ] [ 2fa186b9 ] Received b: 100
-[ INFO ] [ 2fa186b9 ] Simulating Delay
-[ DEBUG ] [ 2fa186b9 ] Calculated sum: 150
-[ INFO ] [ 006a0e32 ] Delay end.
-[ INFO ] [ 0ffd1142 ] Delay end.
-[ INFO ] [ 2fa186b9 ] Delay end.
+[ DEBUG ] [ 4d5fc07c ] Received a: 20
+[ DEBUG ] [ 4d5fc07c ] Received b: 30
+[ INFO  ] [ 4d5fc07c ] Simulating delay
+[ DEBUG ] [ 4d5fc07c ] Calculated sum: 2030
+[ DEBUG ] [ b3862126 ] Received a: 10
+[ DEBUG ] [ b3862126 ] Received b: 50
+[ INFO  ] [ b3862126 ] Simulating delay
+[ DEBUG ] [ b3862126 ] Calculated sum: 1050
+[ DEBUG ] [ 40f72e60 ] Received a: 50
+[ DEBUG ] [ 40f72e60 ] Received b: 100
+[ INFO  ] [ 40f72e60 ] Simulating delay
+[ DEBUG ] [ 40f72e60 ] Calculated sum: 50100
+[ INFO  ] [ 4d5fc07c ] Delay end
+[ INFO  ] [ b3862126 ] Delay end
+[ INFO  ] [ 40f72e60 ] Delay end
 
 ```

--- a/examples/express-ts/README.md
+++ b/examples/express-ts/README.md
@@ -13,15 +13,21 @@ $ yarn start
 ```
 Now you can test it through `curl`. Trigger concurrent requests with different ids that are a part of request context.
 ```
-$ curl localhost:3000 -H X-Id:1 && curl localhost:3000 -H X-Id:2 && curl localhost:3000 -H X-Id:3
+$ curl 'http://localhost:3000?a=20&b=30' && curl 'http://localhost:3000?a=10&b=50' && curl 'http://localhost:3000?a=50&b=100'
 ```
 **Output**
 ```
-[ INFO ] [ 4456b3a2-5362-4302-9897-e0be27e6a6c6 ] X-Id received in the middleware: 1
-[ INFO ] [ 3da70b7d-d580-46f3-9768-76bdb40fb827 ] X-Id received in the middleware: 2
-[ INFO ] [ 480d1b23-fdd4-4d26-92ed-7258d258bf4f ] X-Id received in the middleware: 3
-[ INFO ] [ 4456b3a2-5362-4302-9897-e0be27e6a6c6 ] Request context: 1
-[ INFO ] [ 3da70b7d-d580-46f3-9768-76bdb40fb827 ] Request context: 2
-[ INFO ] [ 480d1b23-fdd4-4d26-92ed-7258d258bf4f ] Request context: 3
+[ DEBUG ] [ 445ef6fb ] Received a: 20
+[ DEBUG ] [ 445ef6fb ] Received b: 30
+[ INFO ] [ 445ef6fb ] Simulating Delay
+[ DEBUG ] [ 445ef6fb ] Calculated sum: 50
+[ DEBUG ] [ b4c27a00 ] Received a: 10
+[ DEBUG ] [ b4c27a00 ] Received b: 50
+[ INFO ] [ b4c27a00 ] Simulating Delay
+[ DEBUG ] [ b4c27a00 ] Calculated sum: 60
+[ DEBUG ] [ a24d4281 ] Received a: 50
+[ DEBUG ] [ a24d4281 ] Received b: 100
+[ INFO ] [ a24d4281 ] Simulating Delay
+[ DEBUG ] [ a24d4281 ] Calculated sum: 150
 
 ```

--- a/examples/express-ts/src/index.ts
+++ b/examples/express-ts/src/index.ts
@@ -12,7 +12,7 @@ const port = 3000;
 app.use(store.initializeMiddleware());
 app.use(requestParams());
 
-app.get('/', add(), async (req: Request, res: Response) => {
+app.get('/', add(), (req: Request, res: Response) => {
   const a = store.get('a');
   const b = store.get('b');
   const sum = store.get('sum');

--- a/examples/express-ts/src/index.ts
+++ b/examples/express-ts/src/index.ts
@@ -3,23 +3,23 @@ import { Request, Response } from 'express';
 
 import * as store from '@leapfrogtechnology/async-store';
 
-import * as service from './service';
-import { requestContext, otherMiddleware } from './middlewares';
+import * as logger from './logger';
+import { requestParams, add } from './middlewares';
 
 const app = express();
 const port = 3000;
 
 app.use(store.initializeMiddleware());
-app.use(requestContext());
+app.use(requestParams());
 
-app.get('/', otherMiddleware, async (req: Request, res: Response) => {
-  await service.doSomething();
+app.get('/', add(), async (req: Request, res: Response) => {
+  const a = store.get('a');
+  const b = store.get('b');
+  const sum = store.get('sum');
 
-  const requestId = store.get('x-id');
-
-  res.send(`Response to request: ${requestId}\n`);
+  res.send(`Sum of ${a}, ${b}: ${sum}\n`);
 });
 
 app.listen(port, () => {
-  process.stdout.write(`Express server listening on port ${port}!\n`);
+  logger.info(`Express server listening on port ${port}!\n`);
 });

--- a/examples/express-ts/src/logger.ts
+++ b/examples/express-ts/src/logger.ts
@@ -1,7 +1,7 @@
 import * as store from '@leapfrogtechnology/async-store';
 
 /**
- * Get unique request id from store or return empty string
+ * Get unique request id from store or return empty string.
  *
  * @returns {string}
  */
@@ -10,7 +10,7 @@ function getRequestId() {
 }
 
 /**
- * A example service to log info with unique request id
+ * A example service to log info with unique request id.
  *
  * @param {string} infoText
  */
@@ -21,7 +21,7 @@ export function info(infoText: string) {
 }
 
 /**
- * A example service to log debug with unique request id
+ * A example service to log debug with unique request id.
  *
  * @param {string} debugText
  */

--- a/examples/express-ts/src/logger.ts
+++ b/examples/express-ts/src/logger.ts
@@ -1,0 +1,12 @@
+import * as store from '@leapfrogtechnology/async-store';
+
+/**
+ * A example service to log info with unique request id
+ *
+ * @param infoText Text to log
+ */
+export function info(infoText: string) {
+  const requestId = store.getId();
+
+  process.stdout.write(`[ INFO ] [ ${requestId} ] ${infoText}`);
+}

--- a/examples/express-ts/src/logger.ts
+++ b/examples/express-ts/src/logger.ts
@@ -3,7 +3,7 @@ import * as store from '@leapfrogtechnology/async-store';
 /**
  * A example service to log info with unique request id
  *
- * @param infoText Text to log
+ * @param {string} infoText
  */
 export function info(infoText: string) {
   const requestId = store.getId();

--- a/examples/express-ts/src/logger.ts
+++ b/examples/express-ts/src/logger.ts
@@ -1,12 +1,32 @@
 import * as store from '@leapfrogtechnology/async-store';
 
 /**
+ * Get unique request id from store or return empty string
+ *
+ * @returns {string}
+ */
+function getRequestId() {
+  return (store.getId() || '').substring(0, 8);
+}
+
+/**
  * A example service to log info with unique request id
  *
  * @param {string} infoText
  */
 export function info(infoText: string) {
-  const requestId = store.getId();
+  const requestId = getRequestId();
 
-  process.stdout.write(`[ INFO ] [ ${requestId} ] ${infoText}`);
+  process.stdout.write(`[ INFO ] ${requestId ? `[ ${requestId} ]` : ''} ${infoText}\n`);
+}
+
+/**
+ * A example service to log debug with unique request id
+ *
+ * @param {string} debugText
+ */
+export function debug(debugText: string) {
+  const requestId = getRequestId();
+
+  process.stdout.write(`[ DEBUG ] ${requestId ? `[ ${requestId} ]` : ''} ${debugText}\n`);
 }

--- a/examples/express-ts/src/logger.ts
+++ b/examples/express-ts/src/logger.ts
@@ -17,7 +17,7 @@ function getRequestId() {
 export function info(text: string) {
   const requestId = getRequestId();
 
-  process.stdout.write(`[ INFO ] ${requestId ? `[ ${requestId} ]` : ''} ${text}\n`);
+  process.stdout.write(`[ INFO  ] ${requestId ? `[ ${requestId} ]` : ''} ${text}\n`);
 }
 
 /**

--- a/examples/express-ts/src/logger.ts
+++ b/examples/express-ts/src/logger.ts
@@ -12,21 +12,21 @@ function getRequestId() {
 /**
  * Write info logs and associated request id to stdout.
  *
- * @param {string} infoText
+ * @param {string} text
  */
-export function info(infoText: string) {
+export function info(text: string) {
   const requestId = getRequestId();
 
-  process.stdout.write(`[ INFO ] ${requestId ? `[ ${requestId} ]` : ''} ${infoText}\n`);
+  process.stdout.write(`[ INFO ] ${requestId ? `[ ${requestId} ]` : ''} ${text}\n`);
 }
 
 /**
  * Write debug logs and associated request id to stdout.
  *
- * @param {string} debugText
+ * @param {string} text
  */
-export function debug(debugText: string) {
+export function debug(text: string) {
   const requestId = getRequestId();
 
-  process.stdout.write(`[ DEBUG ] ${requestId ? `[ ${requestId} ]` : ''} ${debugText}\n`);
+  process.stdout.write(`[ DEBUG ] ${requestId ? `[ ${requestId} ]` : ''} ${text}\n`);
 }

--- a/examples/express-ts/src/logger.ts
+++ b/examples/express-ts/src/logger.ts
@@ -10,7 +10,7 @@ function getRequestId() {
 }
 
 /**
- * A example service to log info with unique request id.
+ * Write info logs and associated request id to stdout.
  *
  * @param {string} infoText
  */
@@ -21,7 +21,7 @@ export function info(infoText: string) {
 }
 
 /**
- * A example service to log debug with unique request id.
+ * Write debug logs and associated request id to stdout.
  *
  * @param {string} debugText
  */

--- a/examples/express-ts/src/middlewares.ts
+++ b/examples/express-ts/src/middlewares.ts
@@ -26,6 +26,28 @@ export function requestParams() {
 }
 
 /**
+ * Middleware to add the parameters `a` and `b` and set `sum` on the async store.
+ *
+ * @returns {(req, res, next) => void}
+ */
+export function add() {
+  return (req: Request, res: Response, next: NextFunction) => {
+    logger.info('Simulating Delay');
+    setTimeout(() => {
+      const a = store.get('a');
+      const b = store.get('b');
+
+      const sum = a + b;
+
+      store.set({ sum });
+      logger.debug(`Calculated sum: ${sum}`);
+
+      next();
+    }, 2000);
+  };
+}
+
+/**
  * Middleware to set the request context `x-id` on the async store.
  *
  * @returns {(req, res, next) => void}

--- a/examples/express-ts/src/middlewares.ts
+++ b/examples/express-ts/src/middlewares.ts
@@ -2,6 +2,7 @@ import * as store from '@leapfrogtechnology/async-store';
 import { Request, Response, NextFunction } from 'express';
 
 import * as logger from './logger';
+import { doSomething } from './service';
 
 /**
  * Middleware to set query params `a` and `b` on async-store.
@@ -31,8 +32,9 @@ export function requestParams() {
  * @returns {(req, res, next) => void}
  */
 export function add() {
-  return (req: Request, res: Response, next: NextFunction) => {
-    logger.info('Simulating Delay');
+  return async (req: Request, res: Response, next: NextFunction) => {
+    await doSomething();
+
     const a = store.get('a');
     const b = store.get('b');
 
@@ -43,30 +45,4 @@ export function add() {
 
     next();
   };
-}
-
-/**
- * Middleware to set the request context `x-id` on the async store.
- *
- * @returns {(req, res, next) => void}
- */
-export function requestContext() {
-  return (req: Request, res: Response, next: NextFunction) => {
-    store.set({ 'x-id': req.header('x-id') });
-
-    next();
-  };
-}
-
-/**
- * Middleware where the value set in the store is available for use.
- *
- * @returns {(req, res, next) => void}
- */
-export function otherMiddleware(req: Request, res: Response, next: NextFunction) {
-  const requestId = store.get('x-id');
-
-  logger.info(`X-Id received in the middleware: ${requestId}\n`);
-
-  next();
 }

--- a/examples/express-ts/src/middlewares.ts
+++ b/examples/express-ts/src/middlewares.ts
@@ -33,17 +33,15 @@ export function requestParams() {
 export function add() {
   return (req: Request, res: Response, next: NextFunction) => {
     logger.info('Simulating Delay');
-    setTimeout(() => {
-      const a = store.get('a');
-      const b = store.get('b');
+    const a = store.get('a');
+    const b = store.get('b');
 
-      const sum = a + b;
+    const sum = a + b;
 
-      store.set({ sum });
-      logger.debug(`Calculated sum: ${sum}`);
+    store.set({ sum });
+    logger.debug(`Calculated sum: ${sum}`);
 
-      next();
-    }, 2000);
+    next();
   };
 }
 

--- a/examples/express-ts/src/middlewares.ts
+++ b/examples/express-ts/src/middlewares.ts
@@ -10,7 +10,7 @@ import { doSomething } from './service';
  * @returns {(req, res, next) => void}
  */
 export function requestParams() {
-  return async (req: Request, res: Response, next: NextFunction) => {
+  return (req: Request, res: Response, next: NextFunction) => {
     const a = req.query.a;
     const b = req.query.b;
 
@@ -32,8 +32,8 @@ export function requestParams() {
  * @returns {(req, res, next) => void}
  */
 export function add() {
-  return async (req: Request, res: Response, next: NextFunction) => {
-    await doSomething();
+  return (req: Request, res: Response, next: NextFunction) => {
+    doSomething();
 
     const a = store.get('a');
     const b = store.get('b');

--- a/examples/express-ts/src/middlewares.ts
+++ b/examples/express-ts/src/middlewares.ts
@@ -14,10 +14,7 @@ export function requestParams() {
     const a = req.query.a;
     const b = req.query.b;
 
-    store.set({
-      a: parseFloat(a) || 0,
-      b: parseFloat(b) || 0
-    });
+    store.set({ a, b });
 
     logger.debug(`Received a: ${a}`);
     logger.debug(`Received b: ${b}`);

--- a/examples/express-ts/src/middlewares.ts
+++ b/examples/express-ts/src/middlewares.ts
@@ -4,7 +4,7 @@ import { Request, Response, NextFunction } from 'express';
 import * as logger from './logger';
 
 /**
- * Middleware to set query params `a` and `b` on async-store
+ * Middleware to set query params `a` and `b` on async-store.
  *
  * @returns {(req, res, next) => void}
  */

--- a/examples/express-ts/src/middlewares.ts
+++ b/examples/express-ts/src/middlewares.ts
@@ -1,5 +1,6 @@
 import * as store from '@leapfrogtechnology/async-store';
 import { Request, Response, NextFunction } from 'express';
+import * as logger from './logger';
 
 /**
  * Middleware to set the request context `x-id` on the async store.
@@ -22,7 +23,7 @@ export function requestContext() {
 export function otherMiddleware(req: Request, res: Response, next: NextFunction) {
   const requestId = store.get('x-id');
 
-  process.stdout.write(`X-Id received in the middleware: ${requestId}\n`);
+  logger.info(`X-Id received in the middleware: ${requestId}\n`);
 
   next();
 }

--- a/examples/express-ts/src/middlewares.ts
+++ b/examples/express-ts/src/middlewares.ts
@@ -1,6 +1,29 @@
 import * as store from '@leapfrogtechnology/async-store';
 import { Request, Response, NextFunction } from 'express';
+
 import * as logger from './logger';
+
+/**
+ * Middleware to set query params `a` and `b` on async-store
+ *
+ * @returns {(req, res, next) => void}
+ */
+export function requestParams() {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const a = req.query.a;
+    const b = req.query.b;
+
+    store.set({
+      a: parseFloat(a) || 0,
+      b: parseFloat(b) || 0
+    });
+
+    logger.debug(`Received a: ${a}`);
+    logger.debug(`Received b: ${b}`);
+
+    next();
+  };
+}
 
 /**
  * Middleware to set the request context `x-id` on the async store.

--- a/examples/express-ts/src/service.ts
+++ b/examples/express-ts/src/service.ts
@@ -1,5 +1,3 @@
-import * as store from '@leapfrogtechnology/async-store';
-
 import * as logger from './logger';
 
 /**
@@ -11,17 +9,6 @@ export async function doSomething() {
   // Do something with the request.
 
   setTimeout(() => {
-    logRequestContext();
+    logger.info('Delay end.');
   }, 2000);
-}
-
-/**
- * An example function making use of the request context set in the store.
- *
- * @returns {Promise<void>}
- */
-async function logRequestContext() {
-  const requestId = store.get('x-id');
-
-  logger.info(`Request context: ${requestId}\n`);
 }

--- a/examples/express-ts/src/service.ts
+++ b/examples/express-ts/src/service.ts
@@ -9,7 +9,9 @@ import * as logger from './logger';
 export async function doSomething() {
   // Do something with the request.
 
-  await Promise.all([() => logRequestContext()]);
+  setTimeout(() => {
+    logRequestContext();
+  }, 2000);
 }
 
 /**

--- a/examples/express-ts/src/service.ts
+++ b/examples/express-ts/src/service.ts
@@ -1,4 +1,5 @@
 import * as store from '@leapfrogtechnology/async-store';
+import * as logger from './logger';
 
 /**
  * An example function making use of the request context set in the store.
@@ -19,5 +20,5 @@ export async function doSomething() {
 async function logRequestContext() {
   const requestId = store.get('x-id');
 
-  process.stdout.write(`Request context: ${requestId}\n`);
+  logger.info(`Request context: ${requestId}\n`);
 }

--- a/examples/express-ts/src/service.ts
+++ b/examples/express-ts/src/service.ts
@@ -1,4 +1,5 @@
 import * as store from '@leapfrogtechnology/async-store';
+
 import * as logger from './logger';
 
 /**

--- a/examples/express-ts/src/service.ts
+++ b/examples/express-ts/src/service.ts
@@ -7,7 +7,7 @@ import * as logger from './logger';
  */
 export function doSomething() {
   // Do something with the request.
-  logger.info('Simulating Delay');
+  logger.info('Simulating delay');
 
   setTimeout(() => {
     logger.info('Delay end.');

--- a/examples/express-ts/src/service.ts
+++ b/examples/express-ts/src/service.ts
@@ -3,9 +3,9 @@ import * as logger from './logger';
 /**
  * An example function making use of the request context set in the store.
  *
- * @returns {Promise<void>}
+ * @returns {void}
  */
-export async function doSomething() {
+export function doSomething() {
   // Do something with the request.
   logger.info('Simulating Delay');
 

--- a/examples/express-ts/src/service.ts
+++ b/examples/express-ts/src/service.ts
@@ -7,6 +7,7 @@ import * as logger from './logger';
  */
 export async function doSomething() {
   // Do something with the request.
+  logger.info('Simulating Delay');
 
   setTimeout(() => {
     logger.info('Delay end.');

--- a/examples/express-ts/src/service.ts
+++ b/examples/express-ts/src/service.ts
@@ -10,6 +10,6 @@ export function doSomething() {
   logger.info('Simulating delay');
 
   setTimeout(() => {
-    logger.info('Delay end.');
+    logger.info('Delay end');
   }, 2000);
 }


### PR DESCRIPTION
Resolves #16 
* Add a simple logging service
    - Log info/debug with a unique request id prepended.

**Output**
```
[ DEBUG ] [ 4d5fc07c ] Received a: 20
[ DEBUG ] [ 4d5fc07c ] Received b: 30
[ INFO  ] [ 4d5fc07c ] Simulating delay
[ DEBUG ] [ 4d5fc07c ] Calculated sum: 2030
[ DEBUG ] [ b3862126 ] Received a: 10
[ DEBUG ] [ b3862126 ] Received b: 50
[ INFO  ] [ b3862126 ] Simulating delay
[ DEBUG ] [ b3862126 ] Calculated sum: 1050
[ DEBUG ] [ 40f72e60 ] Received a: 50
[ DEBUG ] [ 40f72e60 ] Received b: 100
[ INFO  ] [ 40f72e60 ] Simulating delay
[ DEBUG ] [ 40f72e60 ] Calculated sum: 50100
[ INFO  ] [ 4d5fc07c ] Delay end
[ INFO  ] [ b3862126 ] Delay end
[ INFO  ] [ 40f72e60 ] Delay end
```