### PR TITLE
Refactor all the examples for consistency and simplicity 

### DIFF
--- a/examples/express-http-server-ts/README.md
+++ b/examples/express-http-server-ts/README.md
@@ -25,20 +25,27 @@ $ curl 'http://localhost:3000?a=20&b=30' && curl 'http://localhost:3000?a=10&b=5
 **Output**
 
 ```
-[ DEBUG ] [ 4d5fc07c ] Received a: 20
-[ DEBUG ] [ 4d5fc07c ] Received b: 30
-[ INFO  ] [ 4d5fc07c ] Simulating delay
-[ DEBUG ] [ 4d5fc07c ] Calculated sum: 2030
-[ DEBUG ] [ b3862126 ] Received a: 10
-[ DEBUG ] [ b3862126 ] Received b: 50
-[ INFO  ] [ b3862126 ] Simulating delay
-[ DEBUG ] [ b3862126 ] Calculated sum: 1050
-[ DEBUG ] [ 40f72e60 ] Received a: 50
-[ DEBUG ] [ 40f72e60 ] Received b: 100
-[ INFO  ] [ 40f72e60 ] Simulating delay
-[ DEBUG ] [ 40f72e60 ] Calculated sum: 50100
-[ INFO  ] [ 4d5fc07c ] Delay end
-[ INFO  ] [ b3862126 ] Delay end
-[ INFO  ] [ 40f72e60 ] Delay end
+2019-09-28T11:08:35.261Z [ INFO ] HTTP server listening on port 3000!
 
+2019-09-28T11:08:39.987Z [ DEBUG ] f1aa3c12 - Persisted a: 20
+2019-09-28T11:08:39.987Z [ DEBUG ] f1aa3c12 - Persisted b: 30
+2019-09-28T11:08:39.988Z [ DEBUG ] f1aa3c12 - Simulating delayed access
+2019-09-28T11:08:39.988Z [ DEBUG ] f1aa3c12 - Calculated sum: 50
+2019-09-28T11:08:39.988Z [ DEBUG ] f1aa3c12 - Persisted sum: 50
+2019-09-28T11:08:39.991Z [ INFO ] f1aa3c12 - Response sent
+2019-09-28T11:08:40.003Z [ DEBUG ] 81992355 - Persisted a: 10
+2019-09-28T11:08:40.003Z [ DEBUG ] 81992355 - Persisted b: 50
+2019-09-28T11:08:40.003Z [ DEBUG ] 81992355 - Simulating delayed access
+2019-09-28T11:08:40.003Z [ DEBUG ] 81992355 - Calculated sum: 60
+2019-09-28T11:08:40.003Z [ DEBUG ] 81992355 - Persisted sum: 60
+2019-09-28T11:08:40.003Z [ INFO ] 81992355 - Response sent
+2019-09-28T11:08:40.014Z [ DEBUG ] 66fe2219 - Persisted a: 50
+2019-09-28T11:08:40.014Z [ DEBUG ] 66fe2219 - Persisted b: 100
+2019-09-28T11:08:40.014Z [ DEBUG ] 66fe2219 - Simulating delayed access
+2019-09-28T11:08:40.015Z [ DEBUG ] 66fe2219 - Calculated sum: 150
+2019-09-28T11:08:40.015Z [ DEBUG ] 66fe2219 - Persisted sum: 150
+2019-09-28T11:08:40.015Z [ INFO ] 66fe2219 - Response sent
+2019-09-28T11:08:41.988Z [ INFO ] f1aa3c12 - Store contents: {"a":"20","b":"30","sum":50}
+2019-09-28T11:08:42.003Z [ INFO ] 81992355 - Store contents: {"a":"10","b":"50","sum":60}
+2019-09-28T11:08:42.015Z [ INFO ] 66fe2219 - Store contents: {"a":"50","b":"100","sum":150}
 ```

--- a/examples/express-http-server-ts/src/index.ts
+++ b/examples/express-http-server-ts/src/index.ts
@@ -4,7 +4,7 @@ import { Request, Response } from 'express';
 import * as store from '@leapfrogtechnology/async-store';
 
 import * as logger from './logger';
-import { storeParams, add } from './middlewares';
+import { storeParams, calculateSum } from './middlewares';
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -12,7 +12,7 @@ const port = process.env.PORT || 3000;
 app.use(store.initializeMiddleware());
 app.use(storeParams());
 
-app.get('/', add(), (req: Request, res: Response) => {
+app.get('/', calculateSum(), (req: Request, res: Response) => {
   const a = store.get('a');
   const b = store.get('b');
   const sum = store.get('sum');

--- a/examples/express-http-server-ts/src/index.ts
+++ b/examples/express-http-server-ts/src/index.ts
@@ -7,7 +7,7 @@ import * as logger from './logger';
 import { requestParams, add } from './middlewares';
 
 const app = express();
-const port = 3000;
+const port = process.env.PORT || 3000;
 
 app.use(store.initializeMiddleware());
 app.use(requestParams());
@@ -21,5 +21,5 @@ app.get('/', add(), (req: Request, res: Response) => {
 });
 
 app.listen(port, () => {
-  logger.info(`Express server listening on port ${port}!\n`);
+  logger.info(`HTTP server listening on port ${port}!\n`);
 });

--- a/examples/express-http-server-ts/src/index.ts
+++ b/examples/express-http-server-ts/src/index.ts
@@ -4,13 +4,13 @@ import { Request, Response } from 'express';
 import * as store from '@leapfrogtechnology/async-store';
 
 import * as logger from './logger';
-import { requestParams, add } from './middlewares';
+import { storeParams, add } from './middlewares';
 
 const app = express();
 const port = process.env.PORT || 3000;
 
 app.use(store.initializeMiddleware());
-app.use(requestParams());
+app.use(storeParams());
 
 app.get('/', add(), (req: Request, res: Response) => {
   const a = store.get('a');
@@ -18,6 +18,7 @@ app.get('/', add(), (req: Request, res: Response) => {
   const sum = store.get('sum');
 
   res.send(`Sum of ${a}, ${b}: ${sum}\n`);
+  logger.info('Response sent');
 });
 
 app.listen(port, () => {

--- a/examples/express-http-server-ts/src/logger.ts
+++ b/examples/express-http-server-ts/src/logger.ts
@@ -5,28 +5,59 @@ import * as store from '@leapfrogtechnology/async-store';
  *
  * @returns {string}
  */
-function getRequestId() {
+function getRequestId(): string {
   return (store.getId() || '').substring(0, 8);
+}
+
+/**
+ * Print log message to the stdout / stderr.
+ *
+ * @param {string} level
+ * @param {string} requestId
+ * @param {string} message
+ */
+function log(level: string, requestId: string, message: string) {
+  const timestamp = new Date().toISOString();
+  const line = `${timestamp} [ ${level} ] ${requestId ? `${requestId} - ` : ''}${message}\n`;
+
+  if (level === 'ERROR') {
+    process.stderr.write(line);
+
+    return;
+  }
+
+  process.stdout.write(line);
 }
 
 /**
  * Write info logs and associated request id to stdout.
  *
- * @param {string} text
+ * @param {string} message
  */
-export function info(text: string) {
+export function info(message: string) {
   const requestId = getRequestId();
 
-  process.stdout.write(`[ INFO  ] ${requestId ? `[ ${requestId} ]` : ''} ${text}\n`);
+  log('INFO', requestId, message);
 }
 
 /**
  * Write debug logs and associated request id to stdout.
  *
- * @param {string} text
+ * @param {string} message
  */
-export function debug(text: string) {
+export function debug(message: string) {
   const requestId = getRequestId();
 
-  process.stdout.write(`[ DEBUG ] ${requestId ? `[ ${requestId} ]` : ''} ${text}\n`);
+  log('DEBUG', requestId, message);
+}
+
+/**
+ * Write error logs and associated request id to stdout.
+ *
+ * @param {any} err
+ */
+export function error(err: any) {
+  const requestId = getRequestId();
+
+  log('ERROR', requestId, err);
 }

--- a/examples/express-http-server-ts/src/logger.ts
+++ b/examples/express-http-server-ts/src/logger.ts
@@ -13,11 +13,11 @@ function getRequestId(): string {
  * Print log message to the stdout / stderr.
  *
  * @param {string} level
- * @param {string} requestId
  * @param {string} message
  */
-function log(level: string, requestId: string, message: string) {
+function log(level: string, message: string) {
   const timestamp = new Date().toISOString();
+  const requestId = getRequestId();
   const line = `${timestamp} [ ${level} ] ${requestId ? `${requestId} - ` : ''}${message}\n`;
 
   if (level === 'ERROR') {
@@ -35,9 +35,7 @@ function log(level: string, requestId: string, message: string) {
  * @param {string} message
  */
 export function info(message: string) {
-  const requestId = getRequestId();
-
-  log('INFO', requestId, message);
+  log('INFO', message);
 }
 
 /**
@@ -46,9 +44,7 @@ export function info(message: string) {
  * @param {string} message
  */
 export function debug(message: string) {
-  const requestId = getRequestId();
-
-  log('DEBUG', requestId, message);
+  log('DEBUG', message);
 }
 
 /**
@@ -57,7 +53,5 @@ export function debug(message: string) {
  * @param {any} err
  */
 export function error(err: any) {
-  const requestId = getRequestId();
-
-  log('ERROR', requestId, err);
+  log('ERROR', err);
 }

--- a/examples/express-http-server-ts/src/middlewares.ts
+++ b/examples/express-http-server-ts/src/middlewares.ts
@@ -2,22 +2,22 @@ import * as store from '@leapfrogtechnology/async-store';
 import { Request, Response, NextFunction } from 'express';
 
 import * as logger from './logger';
-import { doSomething } from './service';
+import { doSomethingAsync } from './service';
 
 /**
  * Middleware to set query params `a` and `b` on async-store.
  *
  * @returns {(req, res, next) => void}
  */
-export function requestParams() {
+export function storeParams() {
   return (req: Request, res: Response, next: NextFunction) => {
     const a = req.query.a;
     const b = req.query.b;
 
     store.set({ a, b });
 
-    logger.debug(`Received a: ${a}`);
-    logger.debug(`Received b: ${b}`);
+    logger.debug(`Persisted a: ${a}`);
+    logger.debug(`Persisted b: ${b}`);
 
     next();
   };
@@ -30,7 +30,7 @@ export function requestParams() {
  */
 export function add() {
   return (req: Request, res: Response, next: NextFunction) => {
-    doSomething();
+    doSomethingAsync();
 
     const a = store.get('a');
     const b = store.get('b');
@@ -39,6 +39,7 @@ export function add() {
 
     store.set({ sum });
     logger.debug(`Calculated sum: ${sum}`);
+    logger.debug(`Persisted sum: ${sum}`);
 
     next();
   };

--- a/examples/express-http-server-ts/src/middlewares.ts
+++ b/examples/express-http-server-ts/src/middlewares.ts
@@ -11,8 +11,7 @@ import { doSomethingAsync } from './service';
  */
 export function storeParams() {
   return (req: Request, res: Response, next: NextFunction) => {
-    const a = req.query.a;
-    const b = req.query.b;
+    const { a, b } = req.query;
 
     store.set({ a, b });
 
@@ -28,13 +27,12 @@ export function storeParams() {
  *
  * @returns {(req, res, next) => void}
  */
-export function add() {
+export function calculateSum() {
   return (req: Request, res: Response, next: NextFunction) => {
     doSomethingAsync();
 
-    const a = store.get('a');
-    const b = store.get('b');
-
+    const a = +store.get('a');
+    const b = +store.get('b');
     const sum = a + b;
 
     store.set({ sum });

--- a/examples/express-http-server-ts/src/service.ts
+++ b/examples/express-http-server-ts/src/service.ts
@@ -11,8 +11,8 @@ export function doSomethingAsync() {
   logger.debug('Simulating delayed access');
 
   setTimeout(() => {
-    const [a, b, sum, query] = [store.get('a'), store.get('b'), store.get('sum'), store.get('query')];
+    const [a, b, sum] = [store.get('a'), store.get('b'), store.get('sum')];
 
-    logger.info('Store contents: ' + JSON.stringify({ a, b, sum, query }));
+    logger.info('Store contents: ' + JSON.stringify({ a, b, sum }));
   }, 2000);
 }

--- a/examples/express-http-server-ts/src/service.ts
+++ b/examples/express-http-server-ts/src/service.ts
@@ -1,15 +1,18 @@
 import * as logger from './logger';
 
+import * as store from '@leapfrogtechnology/async-store';
+
 /**
- * An example function making use of the request context set in the store.
- *
- * @returns {void}
+ * An example function making use of the request context
+ * set in the store asynchronously (with delay).
  */
-export function doSomething() {
-  // Do something with the request.
-  logger.info('Simulating delay');
+export function doSomethingAsync() {
+  // Do something with the request with a delay.
+  logger.debug('Simulating delayed access');
 
   setTimeout(() => {
-    logger.info('Delay end');
+    const [a, b, sum, query] = [store.get('a'), store.get('b'), store.get('sum'), store.get('query')];
+
+    logger.info('Store contents: ' + JSON.stringify({ a, b, sum, query }));
   }, 2000);
 }

--- a/examples/express-http-server-ts/src/service.ts
+++ b/examples/express-http-server-ts/src/service.ts
@@ -1,6 +1,6 @@
-import * as logger from './logger';
-
 import * as store from '@leapfrogtechnology/async-store';
+
+import * as logger from './logger';
 
 /**
  * An example function making use of the request context

--- a/examples/node-http-server-ts/README.md
+++ b/examples/node-http-server-ts/README.md
@@ -25,19 +25,27 @@ $ curl 'http://localhost:3000?a=20&b=30' && curl 'http://localhost:3000?a=10&b=5
 **Output**
 
 ```plain
-[ DEBUG ] [ acd04c5b ] Received a: 20
-[ DEBUG ] [ acd04c5b ] Received b: 30
-[ INFO  ] [ acd04c5b ] Simulating delay
-[ DEBUG ] [ acd04c5b ] Calculated sum: 50
-[ DEBUG ] [ ece2ec66 ] Received a: 10
-[ DEBUG ] [ ece2ec66 ] Received b: 50
-[ INFO  ] [ ece2ec66 ] Simulating delay
-[ DEBUG ] [ ece2ec66 ] Calculated sum: 60
-[ DEBUG ] [ 0964953f ] Received a: 50
-[ DEBUG ] [ 0964953f ] Received b: 100
-[ INFO  ] [ 0964953f ] Simulating delay
-[ DEBUG ] [ 0964953f ] Calculated sum: 150
-[ INFO  ] [ acd04c5b ] Delay end
-[ INFO  ] [ ece2ec66 ] Delay end
-[ INFO  ] [ 0964953f ] Delay end
+2019-09-28T11:06:55.803Z [ INFO ] HTTP server listening on port 3000!
+
+2019-09-28T11:06:58.172Z [ DEBUG ] 24751fd0 - Persisted a: 20
+2019-09-28T11:06:58.172Z [ DEBUG ] 24751fd0 - Persisted b: 30
+2019-09-28T11:06:58.172Z [ DEBUG ] 24751fd0 - Simulating delayed access
+2019-09-28T11:06:58.172Z [ DEBUG ] 24751fd0 - Calculated sum: 50
+2019-09-28T11:06:58.172Z [ DEBUG ] 24751fd0 - Persisted sum: 50
+2019-09-28T11:06:58.174Z [ INFO ] 24751fd0 - Response sent
+2019-09-28T11:06:58.186Z [ DEBUG ] 8c52e047 - Persisted a: 10
+2019-09-28T11:06:58.186Z [ DEBUG ] 8c52e047 - Persisted b: 50
+2019-09-28T11:06:58.186Z [ DEBUG ] 8c52e047 - Simulating delayed access
+2019-09-28T11:06:58.186Z [ DEBUG ] 8c52e047 - Calculated sum: 60
+2019-09-28T11:06:58.186Z [ DEBUG ] 8c52e047 - Persisted sum: 60
+2019-09-28T11:06:58.186Z [ INFO ] 8c52e047 - Response sent
+2019-09-28T11:06:58.198Z [ DEBUG ] f184da79 - Persisted a: 50
+2019-09-28T11:06:58.198Z [ DEBUG ] f184da79 - Persisted b: 100
+2019-09-28T11:06:58.198Z [ DEBUG ] f184da79 - Simulating delayed access
+2019-09-28T11:06:58.198Z [ DEBUG ] f184da79 - Calculated sum: 150
+2019-09-28T11:06:58.198Z [ DEBUG ] f184da79 - Persisted sum: 150
+2019-09-28T11:06:58.198Z [ INFO ] f184da79 - Response sent
+2019-09-28T11:07:00.175Z [ INFO ] 24751fd0 - Store contents: {"a":"20","b":"30","sum":50}
+2019-09-28T11:07:00.187Z [ INFO ] 8c52e047 - Store contents: {"a":"10","b":"50","sum":60}
+2019-09-28T11:07:00.198Z [ INFO ] f184da79 - Store contents: {"a":"50","b":"100","sum":150}
 ```

--- a/examples/node-http-server-ts/src/index.ts
+++ b/examples/node-http-server-ts/src/index.ts
@@ -1,4 +1,4 @@
-import { IncomingMessage, ServerResponse, createServer } from 'http';
+import * as http from 'http';
 
 import * as logger from './logger';
 import { initializeApp } from './middlewares';
@@ -6,7 +6,7 @@ import { initializeApp } from './middlewares';
 export const PORT = process.env.PORT || 3000;
 export const BASE_URL = `http://localhost:${PORT}`;
 
-const app = createServer(initializeApp);
+const app = http.createServer(initializeApp);
 
 app.listen(PORT, () => {
   logger.info(`Server listening at ${BASE_URL}..\n\n`);

--- a/examples/node-http-server-ts/src/index.ts
+++ b/examples/node-http-server-ts/src/index.ts
@@ -1,12 +1,39 @@
 import * as http from 'http';
+import { IncomingMessage, ServerResponse } from 'http';
+import * as store from '@leapfrogtechnology/async-store';
 
 import * as logger from './logger';
-import { initializeApp } from './middlewares';
+import { storeParams, calculateSum } from './middlewares';
 
 const port = process.env.PORT || 3000;
 
-const app = http.createServer(initializeApp);
+const app = http.createServer((req, res) =>
+  store.initialize()(
+    () => {
+      storeParams((req.url || '').split('?', 2)[1]);
+      calculateSum(req, res);
+      handleRequest(req, res);
+    },
+    { req, res, error: logger.error }
+  )
+);
 
 app.listen(port, () => {
   logger.info(`HTTP server listening on port ${port}!\n`);
 });
+
+/**
+ * Handle incoming http request.
+ *
+ * @param {IncomingMessage} req
+ * @param {ServerResponse} res
+ */
+function handleRequest(req: IncomingMessage, res: ServerResponse) {
+  const a = store.get('a');
+  const b = store.get('b');
+  const sum = store.get('sum');
+
+  res.write(`Sum of ${a}, ${b} = ${sum}\n`);
+  res.end();
+  logger.info('Response sent');
+}

--- a/examples/node-http-server-ts/src/index.ts
+++ b/examples/node-http-server-ts/src/index.ts
@@ -1,4 +1,5 @@
-import * as http from 'http';
+import { IncomingMessage, ServerResponse, createServer } from 'http';
+
 import * as store from '@leapfrogtechnology/async-store';
 import AsyncStoreAdapter from '@leapfrogtechnology/async-store/dist/AsyncStoreAdapter';
 
@@ -14,7 +15,7 @@ export const BASE_URL = `http://localhost:${PORT}`;
  * @param {IncomingMessage} req
  * @param {ServerResponse} res
  */
-function router(req: http.IncomingMessage, res: http.ServerResponse) {
+function router(req: IncomingMessage, res: ServerResponse) {
   const params = (req.url || '').split('?', 2)[1];
 
   store.set({ query: params });
@@ -23,7 +24,7 @@ function router(req: http.IncomingMessage, res: http.ServerResponse) {
   add(req, res);
 }
 
-const app = http.createServer((req: http.IncomingMessage, res: http.ServerResponse) => {
+const app = createServer((req: IncomingMessage, res: ServerResponse) => {
   const init = store.initialize(AsyncStoreAdapter.DOMAIN);
 
   init(() => router(req, res), { req, res, error: logger.error });

--- a/examples/node-http-server-ts/src/index.ts
+++ b/examples/node-http-server-ts/src/index.ts
@@ -1,34 +1,12 @@
 import { IncomingMessage, ServerResponse, createServer } from 'http';
 
-import * as store from '@leapfrogtechnology/async-store';
-import AsyncStoreAdapter from '@leapfrogtechnology/async-store/dist/AsyncStoreAdapter';
-
 import * as logger from './logger';
-import { requestParams, add } from './middlewares';
+import { initializeApp } from './middlewares';
 
 export const PORT = process.env.PORT || 3000;
 export const BASE_URL = `http://localhost:${PORT}`;
 
-/**
- * Main application router
- *
- * @param {IncomingMessage} req
- * @param {ServerResponse} res
- */
-function router(req: IncomingMessage, res: ServerResponse) {
-  const params = (req.url || '').split('?', 2)[1];
-
-  store.set({ query: params });
-
-  requestParams(req, res);
-  add(req, res);
-}
-
-const app = createServer((req: IncomingMessage, res: ServerResponse) => {
-  const init = store.initialize(AsyncStoreAdapter.DOMAIN);
-
-  init(() => router(req, res), { req, res, error: logger.error });
-});
+const app = createServer(initializeApp);
 
 app.listen(PORT, () => {
   logger.info(`Server listening at ${BASE_URL}..\n\n`);

--- a/examples/node-http-server-ts/src/index.ts
+++ b/examples/node-http-server-ts/src/index.ts
@@ -3,11 +3,10 @@ import * as http from 'http';
 import * as logger from './logger';
 import { initializeApp } from './middlewares';
 
-export const PORT = process.env.PORT || 3000;
-export const BASE_URL = `http://localhost:${PORT}`;
+const port = process.env.PORT || 3000;
 
 const app = http.createServer(initializeApp);
 
-app.listen(PORT, () => {
-  logger.info(`Server listening at ${BASE_URL}..\n\n`);
+app.listen(port, () => {
+  logger.info(`HTTP server listening on port ${port}!\n`);
 });

--- a/examples/node-http-server-ts/src/logger.ts
+++ b/examples/node-http-server-ts/src/logger.ts
@@ -13,11 +13,11 @@ function getRequestId(): string {
  * Print log message to the stdout / stderr.
  *
  * @param {string} level
- * @param {string} requestId
  * @param {string} message
  */
-function log(level: string, requestId: string, message: string) {
+function log(level: string, message: string) {
   const timestamp = new Date().toISOString();
+  const requestId = getRequestId();
   const line = `${timestamp} [ ${level} ] ${requestId ? `${requestId} - ` : ''}${message}\n`;
 
   if (level === 'ERROR') {
@@ -35,9 +35,7 @@ function log(level: string, requestId: string, message: string) {
  * @param {string} message
  */
 export function info(message: string) {
-  const requestId = getRequestId();
-
-  log('INFO', requestId, message);
+  log('INFO', message);
 }
 
 /**
@@ -46,9 +44,7 @@ export function info(message: string) {
  * @param {string} message
  */
 export function debug(message: string) {
-  const requestId = getRequestId();
-
-  log('DEBUG', requestId, message);
+  log('DEBUG', message);
 }
 
 /**
@@ -57,7 +53,5 @@ export function debug(message: string) {
  * @param {any} err
  */
 export function error(err: any) {
-  const requestId = getRequestId();
-
-  log('ERROR', requestId, err);
+  log('ERROR', err);
 }

--- a/examples/node-http-server-ts/src/logger.ts
+++ b/examples/node-http-server-ts/src/logger.ts
@@ -5,30 +5,49 @@ import * as store from '@leapfrogtechnology/async-store';
  *
  * @returns {string}
  */
-function getRequestId() {
+function getRequestId(): string {
   return (store.getId() || '').substring(0, 8);
+}
+
+/**
+ * Print log message to the stdout / stderr.
+ *
+ * @param {string} level
+ * @param {string} requestId
+ * @param {string} message
+ */
+function log(level: string, requestId: string, message: string) {
+  const line = `[ ${level} ] ${requestId ? `[ ${requestId} ]` : ''} ${message}\n`;
+
+  if (level === 'ERROR') {
+    process.stderr.write(line);
+
+    return;
+  }
+
+  process.stdout.write(line);
 }
 
 /**
  * Write info logs and associated request id to stdout.
  *
- * @param {string} text
+ * @param {string} message
  */
-export function info(text: string) {
+export function info(message: string) {
   const requestId = getRequestId();
 
-  process.stdout.write(`[ INFO  ] ${requestId ? `[ ${requestId} ]` : ''} ${text}\n`);
+  log('INFO', requestId, message);
 }
 
 /**
  * Write debug logs and associated request id to stdout.
  *
- * @param {string} text
+ * @param {string} message
  */
-export function debug(text: string) {
+export function debug(message: string) {
   const requestId = getRequestId();
 
-  process.stdout.write(`[ DEBUG ] ${requestId ? `[ ${requestId} ]` : ''} ${text}\n`);
+  log('DEBUG', requestId, message);
 }
 
 /**
@@ -39,5 +58,5 @@ export function debug(text: string) {
 export function error(err: any) {
   const requestId = getRequestId();
 
-  process.stdout.write(`[ ERROR ] ${requestId ? `[ ${requestId} ]` : ''} ${err}\n`);
+  log('ERROR', requestId, err);
 }

--- a/examples/node-http-server-ts/src/logger.ts
+++ b/examples/node-http-server-ts/src/logger.ts
@@ -17,7 +17,8 @@ function getRequestId(): string {
  * @param {string} message
  */
 function log(level: string, requestId: string, message: string) {
-  const line = `[ ${level} ] ${requestId ? `[ ${requestId} ]` : ''} ${message}\n`;
+  const timestamp = new Date().toISOString();
+  const line = `${timestamp} [ ${level} ] ${requestId ? `${requestId} - ` : ''}${message}\n`;
 
   if (level === 'ERROR') {
     process.stderr.write(line);

--- a/examples/node-http-server-ts/src/middlewares.ts
+++ b/examples/node-http-server-ts/src/middlewares.ts
@@ -1,11 +1,40 @@
 import * as qs from 'qs';
 import { ServerResponse, IncomingMessage } from 'http';
+
 import * as store from '@leapfrogtechnology/async-store';
+import AsyncStoreAdapter from '@leapfrogtechnology/async-store/dist/AsyncStoreAdapter';
 
 import * as logger from './logger';
 import { doSomething } from './service';
 
 export type Middleware = (req: IncomingMessage, res: ServerResponse) => void;
+
+/**
+ * Handle incoming http request.
+ *
+ * @param {IncomingMessage} req
+ * @param {ServerResponse} res
+ */
+function handleRequest(req: IncomingMessage, res: ServerResponse) {
+  const params = (req.url || '').split('?', 2)[1];
+
+  store.set({ query: params });
+
+  requestParams(req, res);
+  add(req, res);
+}
+
+/**
+ * Listener function for the incoming http requests.
+ *
+ * @param {IncomingMessage} req
+ * @param {ServerResponse} res
+ */
+export function initializeApp(req: IncomingMessage, res: ServerResponse) {
+  const init = store.initialize(AsyncStoreAdapter.DOMAIN);
+
+  init(() => handleRequest(req, res), { req, res, error: logger.error });
+}
 
 /**
  * Middleware to set query params `a` and `b` on async-store.

--- a/examples/node-http-server-ts/src/middlewares.ts
+++ b/examples/node-http-server-ts/src/middlewares.ts
@@ -2,46 +2,17 @@ import * as qs from 'qs';
 import { ServerResponse, IncomingMessage } from 'http';
 
 import * as store from '@leapfrogtechnology/async-store';
-import AsyncStoreAdapter from '@leapfrogtechnology/async-store/dist/AsyncStoreAdapter';
 
 import * as logger from './logger';
 import { doSomethingAsync } from './service';
 
 /**
- * Listener function for the incoming http requests.
- *
- * @param {IncomingMessage} req
- * @param {ServerResponse} res
- */
-export function initializeApp(req: IncomingMessage, res: ServerResponse) {
-  const initStore = store.initialize(AsyncStoreAdapter.DOMAIN);
-
-  initStore(() => handleRequest(req, res), { req, res, error: logger.error });
-}
-
-/**
- * Handle incoming http request.
- *
- * @param {IncomingMessage} req
- * @param {ServerResponse} res
- */
-function handleRequest(req: IncomingMessage, res: ServerResponse) {
-  const params = (req.url || '').split('?', 2)[1];
-
-  store.set({ query: params });
-
-  storeParams(req, res);
-  add(req, res);
-}
-
-/**
  * Set input params received from query in the store.
  *
- * @param {IncomingMessage} req
- * @param {ServerResponse} res
+ * @param {any} query
  */
-function storeParams(req: IncomingMessage, res: ServerResponse) {
-  const { a, b } = qs.parse(store.get('query'));
+export function storeParams(query: any) {
+  const { a, b } = qs.parse(query);
 
   store.set({ a, b });
 
@@ -55,20 +26,14 @@ function storeParams(req: IncomingMessage, res: ServerResponse) {
  * @param {IncomingMessage} req
  * @param {ServerResponse} res
  */
-function add(req: IncomingMessage, res: ServerResponse) {
+export function calculateSum(req: IncomingMessage, res: ServerResponse) {
   doSomethingAsync();
 
   const a = +store.get('a');
   const b = +store.get('b');
-
   const sum = a + b;
 
-  logger.debug(`Calculated sum: ${sum}`);
-
   store.set({ sum });
+  logger.debug(`Calculated sum: ${sum}`);
   logger.debug(`Persisted sum: ${sum}`);
-
-  res.write(`Sum of ${a}, ${b} = ${sum}\n`);
-  res.end();
-  logger.info('Response sent');
 }

--- a/examples/node-http-server-ts/src/service.ts
+++ b/examples/node-http-server-ts/src/service.ts
@@ -1,6 +1,21 @@
+import * as qs from 'qs';
 import * as logger from './logger';
 
 import * as store from '@leapfrogtechnology/async-store';
+
+/**
+ * Set input params received from query in the store.
+ *
+ * @param {any} query
+ */
+export function storeParams(query: any) {
+  const { a, b } = qs.parse(query);
+
+  store.set({ a, b });
+
+  logger.debug(`Persisted a: ${a}`);
+  logger.debug(`Persisted b: ${b}`);
+}
 
 /**
  * An example function making use of the request context

--- a/examples/node-http-server-ts/src/service.ts
+++ b/examples/node-http-server-ts/src/service.ts
@@ -1,13 +1,18 @@
 import * as logger from './logger';
 
+import * as store from '@leapfrogtechnology/async-store';
+
 /**
- * An example function making use of the request context set in the store.
+ * An example function making use of the request context
+ * set in the store asynchronously (with delay).
  */
-export function doSomething() {
-  // Do something with the request.
-  logger.info('Simulating delay');
+export function doSomethingAsync() {
+  // Do something with the request with a delay.
+  logger.debug('Simulating delayed access');
 
   setTimeout(() => {
-    logger.info('Delay end');
+    const [a, b, sum, query] = [store.get('a'), store.get('b'), store.get('sum'), store.get('query')];
+
+    logger.info('Store contents: ' + JSON.stringify({ a, b, sum, query }));
   }, 2000);
 }

--- a/examples/node-http-server-ts/src/service.ts
+++ b/examples/node-http-server-ts/src/service.ts
@@ -2,8 +2,6 @@ import * as logger from './logger';
 
 /**
  * An example function making use of the request context set in the store.
- *
- * @returns {void}
  */
 export function doSomething() {
   // Do something with the request.

--- a/examples/node-http-server-ts/src/service.ts
+++ b/examples/node-http-server-ts/src/service.ts
@@ -26,8 +26,8 @@ export function doSomethingAsync() {
   logger.debug('Simulating delayed access');
 
   setTimeout(() => {
-    const [a, b, sum, query] = [store.get('a'), store.get('b'), store.get('sum'), store.get('query')];
+    const [a, b, sum] = [store.get('a'), store.get('b'), store.get('sum')];
 
-    logger.info('Store contents: ' + JSON.stringify({ a, b, sum, query }));
+    logger.info('Store contents: ' + JSON.stringify({ a, b, sum }));
   }, 2000);
 }


### PR DESCRIPTION
Refactor examples for consistency and simplicity.
 - Refactor node example
 - Refactor express example
 - Refactor logger - add timestamp and tweaked the format a bit

**New output for both examples**
```
2019-09-28T11:08:35.261Z [ INFO ] HTTP server listening on port 3000!
2019-09-28T11:08:39.987Z [ DEBUG ] f1aa3c12 - Persisted a: 20
2019-09-28T11:08:39.987Z [ DEBUG ] f1aa3c12 - Persisted b: 30
2019-09-28T11:08:39.988Z [ DEBUG ] f1aa3c12 - Simulating delayed access
2019-09-28T11:08:39.988Z [ DEBUG ] f1aa3c12 - Calculated sum: 50
2019-09-28T11:08:39.988Z [ DEBUG ] f1aa3c12 - Persisted sum: 50
2019-09-28T11:08:39.991Z [ INFO ] f1aa3c12 - Response sent
2019-09-28T11:08:40.003Z [ DEBUG ] 81992355 - Persisted a: 10
2019-09-28T11:08:40.003Z [ DEBUG ] 81992355 - Persisted b: 50
2019-09-28T11:08:40.003Z [ DEBUG ] 81992355 - Simulating delayed access
2019-09-28T11:08:40.003Z [ DEBUG ] 81992355 - Calculated sum: 60
2019-09-28T11:08:40.003Z [ DEBUG ] 81992355 - Persisted sum: 60
2019-09-28T11:08:40.003Z [ INFO ] 81992355 - Response sent
2019-09-28T11:08:40.014Z [ DEBUG ] 66fe2219 - Persisted a: 50
2019-09-28T11:08:40.014Z [ DEBUG ] 66fe2219 - Persisted b: 100
2019-09-28T11:08:40.014Z [ DEBUG ] 66fe2219 - Simulating delayed access
2019-09-28T11:08:40.015Z [ DEBUG ] 66fe2219 - Calculated sum: 150
2019-09-28T11:08:40.015Z [ DEBUG ] 66fe2219 - Persisted sum: 150
2019-09-28T11:08:40.015Z [ INFO ] 66fe2219 - Response sent
2019-09-28T11:08:41.988Z [ INFO ] f1aa3c12 - Store contents: {"a":"20","b":"30","sum":50}
2019-09-28T11:08:42.003Z [ INFO ] 81992355 - Store contents: {"a":"10","b":"50","sum":60}
2019-09-28T11:08:42.015Z [ INFO ] 66fe2219 - Store contents: {"a":"50","b":"100","sum":150}
```
