### PR TITLE
Add new accessor function getByKeys()

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,16 @@ Gets a value by a key from the store.
 const foo = store.get('foo');
 ```
 
-### getByKeys()
+### getByKeys<T>()
 
-Gets multiple values by key from the store, and returns an object with those keys and their corresponding values.
+Gets multiple values by key from the store, returns them in the same order they were requested.
 
 - `@params {Array<string> keys}` - Keys to get from the store
-- `@returns {any}` - Returns and object with the values found for those keys (any keys not found are mapped to `undefined`). 
+- `@returns {T[]}` - Returns an array of those objects, in the same order they were requested.
+
+```js
+let [a, b, sum] = store.get(['a', 'b', 'sum']);
+```
 
 ### find()
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ Gets a value by a key from the store.
 const foo = store.get('foo');
 ```
 
+### getByKeys()
+
+Gets multiple values by key from the store, and returns an object with those keys and their corresponding values.
+
+- `@params {Array<string> keys}` - Keys to get from the store
+- `@returns {any}` - Returns and object with the values found for those keys (any keys not found are mapped to `undefined`). 
+
 ### find()
 
 Gets a value by a key from the store. If anything fails, it returns `null` without emitting error event.

--- a/src/AsyncStore.ts
+++ b/src/AsyncStore.ts
@@ -7,6 +7,7 @@ interface AsyncStore {
   initialize: (callback: (err?: any) => void, params?: AsyncStoreParams) => void;
   set: (properties: any) => void;
   get: (key: string) => any;
+  getByKeys: (keys: string[]) => any;
   find: (key: string) => any;
   isInitialized: () => boolean;
   getId: () => string | undefined;

--- a/src/impl/domain.ts
+++ b/src/impl/domain.ts
@@ -120,24 +120,20 @@ export function get(key: string): any {
 
 /**
  * Retrieves all values that correspond to a given list of keys.
+ * Any keys not found are included in-order as `undefined`.
  *
  * Example:
  *  const a = 1;
  *  const b = 2;
  *  const sum = a + b;
  *  store.set({a, b, sum})
- *  const results = store.getByKeys(['a', 'b', 'sum']); // {a: 1, b: 2, sum: 3}
+ *  const results = store.getByKeys(['a', 'b', 'other', 'sum']); // [1, 2, undefined, 3]
  *
- * @param {Array<string>} keys
- * @returns {*}
+ * @param {string[]} keys
+ * @returns {T[]}
  */
-export function getByKeys(keys: string[]): any {
-  const result: any = {};
-  keys.forEach(key => {
-    result[key] = get(key);
-  });
-
-  return result;
+export function getByKeys<T>(keys: string[]): T[] {
+  return keys.map(key => get(key));
 }
 
 /**

--- a/src/impl/domain.ts
+++ b/src/impl/domain.ts
@@ -119,6 +119,28 @@ export function get(key: string): any {
 }
 
 /**
+ * Retrieves all values that correspond to a given list of keys.
+ *
+ * Example:
+ *  const a = 1;
+ *  const b = 2;
+ *  const sum = a + b;
+ *  store.set({a, b, sum})
+ *  const results = store.getByKeys(['a', 'b', 'sum']); // {a: 1, b: 2, sum: 3}
+ *
+ * @param {Array<string>} keys
+ * @returns {*}
+ */
+export function getByKeys(keys: string[]): any {
+  const result: any = {};
+  keys.forEach(key => {
+    result[key] = get(key);
+  });
+
+  return result;
+}
+
+/**
  * Get a value by a key from the store.
  * If anything fails, it returns null without emitting error event.
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,18 +138,19 @@ export function get(key: string): any {
 
 /**
  * Retrieves all values that correspond to a given list of keys.
+ * Any keys not found are included in-order as `undefined`.
  *
  * Example:
  *  const a = 1;
  *  const b = 2;
  *  const sum = a + b;
  *  store.set({a, b, sum})
- *  const results = store.getByKeys(['a', 'b', 'sum']); // {a: 1, b: 2, sum: 3}
+ *  const results = store.getByKeys(['a', 'b', 'other', 'sum']); // [1, 2, undefined, 3]
  *
- * @param {Array<string>} keys
- * @returns {*}
+ * @param {string[]} keys
+ * @returns {T[]}
  */
-export function getByKeys(keys: string[]): any {
+export function getByKeys<T>(keys: string[]): T[] {
   coreLog(`Getting ${keys.join(', ')} from the store`);
 
   return initializedAdapter && getInstance(initializedAdapter).getByKeys(keys);

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,25 @@ export function get(key: string): any {
 }
 
 /**
+ * Retrieves all values that correspond to a given list of keys.
+ *
+ * Example:
+ *  const a = 1;
+ *  const b = 2;
+ *  const sum = a + b;
+ *  store.set({a, b, sum})
+ *  const results = store.getByKeys(['a', 'b', 'sum']); // {a: 1, b: 2, sum: 3}
+ *
+ * @param {Array<string>} keys
+ * @returns {*}
+ */
+export function getByKeys(keys: string[]): any {
+  coreLog(`Getting ${keys.join(', ')} from the store`);
+
+  return initializedAdapter && getInstance(initializedAdapter).getByKeys(keys);
+}
+
+/**
  * Get a value by a key from the store.
  * If error, it returns null without emitting error event.
  *

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -59,9 +59,9 @@ describe('store: [adapter=DOMAIN]', () => {
       expect(globalStore.get.bind(globalStore, 'foo')).to.throw('No active domain found in store.');
     });
 
-    it('should return an object with `undefined` as the value for the requested key if that key was not set.', done => {
+    it('should return `undefined` as the value for requested keys that were not set.', done => {
       const callback = () => {
-        expect(globalStore.getByKeys(['foo'])).to.deep.equal([undefined]);
+        expect(globalStore.getByKeys(['foo', 'bar'])).to.deep.equal([undefined, undefined]);
         done();
       };
 

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -61,7 +61,19 @@ describe('store: [adapter=DOMAIN]', () => {
 
     it('should return an object with `undefined` as the value for the requested key if that key was not set.', done => {
       const callback = () => {
-        expect(globalStore.getByKeys(['foo'])).to.deep.equal({ foo: undefined });
+        expect(globalStore.getByKeys(['foo'])).to.deep.equal([undefined]);
+        done();
+      };
+
+      globalStore.initialize(adapter)(callback);
+    });
+
+    it('should return an array of matching values in the same order as the list of requested keys.', done => {
+      const callback = () => {
+        globalStore.set({ a: 1, b: 2, sum: 3, somethingNull: null });
+
+        expect(globalStore.getByKeys(['a', 'b', 'somethingNull', 'sum'])).to.deep.equal([1, 2, null, 3]);
+
         done();
       };
 
@@ -281,7 +293,7 @@ describe('store: [adapter=DOMAIN]', () => {
 
         globalStore.set({ foo: 'Foo' });
 
-        expect(globalStore.getByKeys(['foo', 'bar'])).to.deep.equal({ foo: 'Foo', bar: 'bar' });
+        expect(globalStore.get('foo')).to.equal('Foo');
       };
 
       const third = () => {
@@ -298,7 +310,7 @@ describe('store: [adapter=DOMAIN]', () => {
             expect(globalStore.get('foo')).to.equal('bar');
           })
           .then(() => {
-            expect(globalStore.getByKeys(['foo', 'bar'])).to.deep.equal({ foo: 'bar', bar: 'bonk' });
+            expect(globalStore.get('foo')).to.equal('bar');
           })
           .then(() => {
             expect(globalStore.get('foo')).to.equal('bar');

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -54,6 +54,21 @@ describe('store: [adapter=DOMAIN]', () => {
     });
   });
 
+  describe('getByKeys()', () => {
+    it('should throw an error if store not initialized.', () => {
+      expect(globalStore.get.bind(globalStore, 'foo')).to.throw('No active domain found in store.');
+    });
+
+    it('should return an object with `undefined` as the value for the requested key if that key was not set.', done => {
+      const callback = () => {
+        expect(globalStore.getByKeys(['foo'])).to.deep.equal({ foo: undefined });
+        done();
+      };
+
+      globalStore.initialize(adapter)(callback);
+    });
+  });
+
   describe('getId()', () => {
     it('should return unique value if store is initialized', done => {
       const callback = () => {
@@ -249,7 +264,7 @@ describe('store: [adapter=DOMAIN]', () => {
   describe('Test Cases:', () => {
     it('should work with a chain of sequentially invoked callbacks (synchronous).', done => {
       const callback = () => {
-        globalStore.set({ foo: 'foo' });
+        globalStore.set({ foo: 'foo', bar: 'bar' });
 
         first();
         second();
@@ -266,7 +281,7 @@ describe('store: [adapter=DOMAIN]', () => {
 
         globalStore.set({ foo: 'Foo' });
 
-        expect(globalStore.get('foo')).to.equal('Foo');
+        expect(globalStore.getByKeys(['foo', 'bar'])).to.deep.equal({ foo: 'Foo', bar: 'bar' });
       };
 
       const third = () => {
@@ -283,7 +298,7 @@ describe('store: [adapter=DOMAIN]', () => {
             expect(globalStore.get('foo')).to.equal('bar');
           })
           .then(() => {
-            expect(globalStore.get('foo')).to.equal('bar');
+            expect(globalStore.getByKeys(['foo', 'bar'])).to.deep.equal({ foo: 'bar', bar: 'bonk' });
           })
           .then(() => {
             expect(globalStore.get('foo')).to.equal('bar');
@@ -296,7 +311,7 @@ describe('store: [adapter=DOMAIN]', () => {
           });
 
       const callback = () => {
-        globalStore.set({ foo: 'bar' });
+        globalStore.set({ foo: 'bar', bar: 'bonk' });
 
         doSomething().then(done);
       };


### PR DESCRIPTION
Added the `getByKeys()` method described in #28, and exercised it in some tests (and updated the README). Y'all's changelog appears autogenerated, so I didn't touch that, as a heads-up.

Sorry for the multiple "referenced a commit" over on the issue -- to keep things clean and down to a single commit, I kept force-pushing to my own fork repo (normally bad form, I know, but for a quick PR branch I figured it seemed alright).

Fixes https://github.com/leapfrogtechnology/async-store/issues/28