### PR TITLE
Add implementation to get short id from store.getId() using a flag

### DIFF
--- a/src/AsyncStore.ts
+++ b/src/AsyncStore.ts
@@ -10,7 +10,7 @@ interface AsyncStore {
   getByKeys: (keys: string[]) => any;
   find: (key: string) => any;
   isInitialized: () => boolean;
-  getId: () => string | undefined;
+  getId: (short: boolean) => string | undefined;
 }
 
 export default AsyncStore;

--- a/src/impl/domain.ts
+++ b/src/impl/domain.ts
@@ -211,7 +211,6 @@ export function getActiveDomain(): StoreDomainInterface {
 
 /**
  * Get's the unique domain id created for the current context / scope.
- * Returns full id by default. Set `short` to true to get short id.
  *
  * Example:
  * ```
@@ -220,7 +219,7 @@ export function getActiveDomain(): StoreDomainInterface {
  * ```
  *
  * @param {boolean} short Set `true` to get short id. Default `false`
- * @returns {(string | undefined)}
+ * @returns {(string | undefined)} Returns full id by default. Set `short` to true to get short id.
  */
 export function getId(short: boolean = false): string | undefined {
   const activeDomain = getActiveDomain();

--- a/src/impl/domain.ts
+++ b/src/impl/domain.ts
@@ -211,13 +211,26 @@ export function getActiveDomain(): StoreDomainInterface {
 
 /**
  * Get's the unique domain id created for the current context / scope.
+ * Returns full id by default. Set `short` to true to get short id.
  *
+ * Example:
+ * ```
+ * store.getId(); // Returns full id
+ * store.getId(true); // Returns first 8 characters of id. Default false
+ * ```
+ *
+ * @param {boolean} short Set `true` to get short id. Default `false`
  * @returns {(string | undefined)}
  */
-export function getId(): string | undefined {
+export function getId(short: boolean = false): string | undefined {
   const activeDomain = getActiveDomain();
+  const id = activeDomain && activeDomain[ID_KEY];
 
-  return activeDomain && activeDomain[ID_KEY];
+  if (short) {
+    return id && id.substring(0, 8);
+  }
+
+  return id;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -180,12 +180,20 @@ export function isInitialized(): boolean {
 }
 
 /**
- * Gets the unique domain id created for the current context / scope.
+ * Get's the unique domain id created for the current context / scope.
+ * Returns full id by default. Set `short` to true to get short id.
  *
+ * Example:
+ * ```
+ * store.getId(); // Returns full id
+ * store.getId(true); // Returns short id if set `true`. Default false
+ * ```
+ *
+ * @param {boolean} short Set `true` to get short id. Default `false`
  * @returns {(string | undefined)}
  */
-export function getId(): string | undefined {
-  return initializedAdapter && getInstance(initializedAdapter).getId();
+export function getId(short: boolean = false): string | undefined {
+  return initializedAdapter && getInstance(initializedAdapter).getId(short);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,6 @@ export function isInitialized(): boolean {
 
 /**
  * Get's the unique domain id created for the current context / scope.
- * Returns full id by default. Set `short` to true to get short id.
  *
  * Example:
  * ```
@@ -190,7 +189,7 @@ export function isInitialized(): boolean {
  * ```
  *
  * @param {boolean} short Set `true` to get short id. Default `false`
- * @returns {(string | undefined)}
+ * @returns {(string | undefined)} Returns full id by default. Set `short` to true to get short id.
  */
 export function getId(short: boolean = false): string | undefined {
   return initializedAdapter && getInstance(initializedAdapter).getId(short);


### PR DESCRIPTION
Resolves #26 
- Add `short` flag in `getId` to get short unique domain id.
    * Domain Implementation: Return first 8 characters of unique domain id if `short` is set.