### PR TITLE
Add implementation to get short id

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ const requestIdentifier = store.getId();
 
 Gets the short unique store id created for the current context/scope.
 
+Note: This is same as `getId();` the difference being it only returns the first 8 characters.
+
 - `@returns {string | undefined}` - Returns the short unique store id.
 
 ```js

--- a/README.md
+++ b/README.md
@@ -227,6 +227,16 @@ Example: If used in express, it returns unique store id per request.
 const requestIdentifier = store.getId();
 ```
 
+### getShortId()
+
+Gets the short unique store id created for the current context/scope.
+
+- `@returns {string | undefined}` - Returns the short unique store id.
+
+```js
+const requestIdentifier = store.getShortId();
+```
+
 ## Changelog
 
 Check the [CHANGELOG](CHANGELOG.md) for release history.

--- a/src/AsyncStore.ts
+++ b/src/AsyncStore.ts
@@ -12,6 +12,7 @@ interface AsyncStore {
   find: (key: string) => any;
   isInitialized: () => boolean;
   getId: () => string | undefined;
+  getShortId: () => string | undefined;
 }
 
 export default AsyncStore;

--- a/src/impl/domain.ts
+++ b/src/impl/domain.ts
@@ -235,6 +235,18 @@ export function getId(): string | undefined {
 }
 
 /**
+ * Gets the short unique domain id created for the current context / scope.
+ *
+ * @returns {(string | undefined)}
+ */
+export function getShortId(): string | undefined {
+  const activeDomain = getActiveDomain();
+  const id = activeDomain && activeDomain[ID_KEY];
+
+  return id && id.substring(0, 8);
+}
+
+/**
  * Get the store from the active domain.
  *
  * @returns {*}

--- a/src/impl/domain.ts
+++ b/src/impl/domain.ts
@@ -240,8 +240,7 @@ export function getId(): string | undefined {
  * @returns {(string | undefined)}
  */
 export function getShortId(): string | undefined {
-  const activeDomain = getActiveDomain();
-  const id = activeDomain && activeDomain[ID_KEY];
+  const id = getId();
 
   return id && id.substring(0, 8);
 }

--- a/src/impl/domain.ts
+++ b/src/impl/domain.ts
@@ -237,6 +237,8 @@ export function getId(): string | undefined {
 /**
  * Gets the short unique domain id created for the current context / scope.
  *
+ * Note: This is same as `getId();` the difference being it only returns the first 8 characters.
+ *
  * @returns {(string | undefined)}
  */
 export function getShortId(): string | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,6 +202,8 @@ export function getId(): string | undefined {
 /**
  * Gets the short unique domain id created for the current context / scope.
  *
+ * Note: This is same as `getId();` the difference being it only returns the first 8 characters.
+ *
  * @returns {(string | undefined)}
  */
 export function getShortId(): string | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,6 +200,15 @@ export function getId(): string | undefined {
 }
 
 /**
+ * Gets the short unique domain id created for the current context / scope.
+ *
+ * @returns {(string | undefined)}
+ */
+export function getShortId(): string | undefined {
+  return initializedAdapter && getInstance(initializedAdapter).getShortId();
+}
+
+/**
  * Get the adapter instance based on adapter type.
  *
  * @param {AsyncStoreAdapter} adapter

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -212,6 +212,28 @@ describe('store: [adapter=DOMAIN]', () => {
     });
   });
 
+  describe('getShortId()', () => {
+    it('should return short (8 chars) unique value if store is initialized.', done => {
+      const callback = () => {
+        expect(globalStore.getShortId()).to.be.an('string');
+        expect(globalStore.getShortId()).to.not.equal(null);
+        expect(globalStore.getShortId()).to.not.equal(undefined);
+        expect(globalStore.getShortId()).to.be.lengthOf(8);
+
+        done();
+      };
+
+      globalStore.initialize(adapter)(callback);
+    });
+
+    it('should return `undefined` if store is not initialized.', done => {
+      expect(globalStore.getShortId).to.not.throw();
+      expect(globalStore.getShortId()).to.equal(undefined);
+
+      done();
+    });
+  });
+
   describe('find()', () => {
     it('should successfully return value in synchronous callback.', done => {
       const callback = () => {


### PR DESCRIPTION
Resolves #26 

- Add `getShortId` method to get short unique domain id.