### PR TITLE
Fix: return response from callback

### DIFF
--- a/src/AsyncStore.ts
+++ b/src/AsyncStore.ts
@@ -4,7 +4,7 @@ import AsyncStoreParams from './AsyncStoreParams';
  * Async Store implementation contract.
  */
 interface AsyncStore {
-  initialize: (callback: (err?: any) => void, params?: AsyncStoreParams) => void;
+  initialize: (callback: (err?: any) => void, params?: AsyncStoreParams) => any;
   set: (properties: any) => void;
   get: (key: string) => any;
   getAll: () => any;

--- a/src/impl/domain.ts
+++ b/src/impl/domain.ts
@@ -28,7 +28,7 @@ export function initialize(callback: (err?: any) => void, params?: AsyncStorePar
   d[STORE_KEY] = Object.create(null);
   d[ID_KEY] = randomUUID();
 
-  d.run(callback);
+  return d.run(callback);
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,7 @@ export function initializeFastifyPlugin(adapter: AsyncStoreAdapter = AsyncStoreA
  * Initialize the async store based on the adapter provided.
  *
  * @param {AsyncStoreAdapter} [adapter=AsyncStoreAdapter.DOMAIN]
- * @returns {(params: AsyncStoreParams) => void}
+ * @returns {(params: AsyncStoreParams) => any}
  */
 export function initialize(adapter: AsyncStoreAdapter = AsyncStoreAdapter.DOMAIN) {
   if (isInitialized()) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ export function initialize(adapter: AsyncStoreAdapter = AsyncStoreAdapter.DOMAIN
   return (callback: (err?: any) => void, params?: AsyncStoreParams) => {
     initializedAdapter = adapter;
 
-    instance.initialize(callback, params);
+    return instance.initialize(callback, params);
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,7 @@ export function initializeFastifyPlugin(adapter: AsyncStoreAdapter = AsyncStoreA
  * Initialize the async store based on the adapter provided.
  *
  * @param {AsyncStoreAdapter} [adapter=AsyncStoreAdapter.DOMAIN]
- * @returns {(params: AsyncStoreParams) => any}
+ * @returns {(callback: (err?: any) => void, params?: AsyncStoreParams) => any }
  */
 export function initialize(adapter: AsyncStoreAdapter = AsyncStoreAdapter.DOMAIN) {
   if (isInitialized()) {

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -839,5 +839,120 @@ describe('store: [adapter=DOMAIN]', () => {
         globalStore.initialize(adapter)(callback);
       });
     });
+
+    it("should work even if the store is initialized under active domain w/o affecting the existing domain's attributes.", (done) => {
+      // Existing domain.
+      const d = domain.create() as any;
+
+      d.existingData = 'Hello world';
+
+      const callback = () => {
+        Promise.resolve().then(first).then(second).then(third).then(done).catch(done);
+      };
+
+      const first = () => {
+        globalStore.set({ foo: 'foo' });
+      };
+
+      const second = () => {
+        // Store should still have the data set.
+        expect(globalStore.get('foo')).to.equal('foo');
+
+        // And the existing data in the domain before our store
+        // was initialized should still be there.
+        expect((process.domain as any).existingData).to.equal('Hello world');
+      };
+
+      const third = () => {
+        // Ensure the same existing domain is used instead of creating a new one.
+        expect(process.domain).to.equal(d);
+      };
+
+      d.run(() => {
+        // Ensure data in the existing domain is available at this point.
+        expect((process.domain as any).existingData).to.equal('Hello world');
+
+        globalStore.initialize(adapter)(callback);
+      });
+    });
+    it("should work even if the store is initialized under active domain w/o affecting the existing domain's attributes.", (done) => {
+      // Existing domain.
+      const d = domain.create() as any;
+
+      d.existingData = 'Hello world';
+
+      const callback = () => {
+        Promise.resolve().then(first).then(second).then(third).then(done).catch(done);
+      };
+
+      const first = () => {
+        globalStore.set({ foo: 'foo' });
+      };
+
+      const second = () => {
+        // Store should still have the data set.
+        expect(globalStore.get('foo')).to.equal('foo');
+
+        // And the existing data in the domain before our store
+        // was initialized should still be there.
+        expect((process.domain as any).existingData).to.equal('Hello world');
+      };
+
+      const third = () => {
+        // Ensure the same existing domain is used instead of creating a new one.
+        expect(process.domain).to.equal(d);
+      };
+
+      d.run(() => {
+        // Ensure data in the existing domain is available at this point.
+        expect((process.domain as any).existingData).to.equal('Hello world');
+
+        globalStore.initialize(adapter)(callback);
+      });
+    });
+
+    it('should return the same response from the callback function.', async () => {
+      const callback = async () => {
+        globalStore.set({ foo: 'foo' });
+
+        return Promise.resolve('Hello world');
+      };
+
+      const response = await globalStore.initialize(adapter)(callback);
+
+      expect(response).to.equal('Hello world');
+    });
+  });
+
+  describe('Error Handling:', () => {
+    it('should bubble up the promise rejection from the callback.', async () => {
+      const callback = async () => {
+        globalStore.set({ foo: 'foo' });
+
+        return Promise.reject('Hello world');
+      };
+
+      try {
+        await globalStore.initialize(adapter)(callback);
+      } catch (e) {
+        expect(e).to.equal('Hello world');
+      }
+    });
+
+    it('should bubble up the error thrown from the callback.', async () => {
+      const callback = async () => {
+        globalStore.set({ foo: 'foo' });
+
+        throw new Error('Hello world');
+      };
+
+      try {
+        await globalStore.initialize(adapter)(callback);
+      } catch (e) {
+        if (e instanceof Error) {
+          expect(e.message).to.equal('Hello world');
+        }
+      }
+    });
   });
 });

--- a/test/domain.test.ts
+++ b/test/domain.test.ts
@@ -840,6 +840,23 @@ describe('store: [adapter=DOMAIN]', () => {
       });
     });
 
+    it('should return the response from callback function.', (done) => {
+      const callback = () => {
+        globalStore.set({ foo: 'foo' });
+
+        return functionAccessingStore();
+      };
+
+      const functionAccessingStore = () => {
+        return globalStore.get('foo');
+      };
+
+      const response = globalStore.initialize(adapter)(callback);
+      expect(response).to.equal('foo');
+
+      done();
+    });
+
     it('should return the response from async callback function.', async () => {
       const callback = async () => {
         globalStore.set({ foo: 'foo' });
@@ -872,9 +889,9 @@ describe('store: [adapter=DOMAIN]', () => {
       const callback = () => {
         globalStore.set({ foo: 'foo' });
 
-        return new Promise((resolve, rejects) => {
+        return new Promise((resolve, reject) => {
           setTimeout(() => {
-            rejects('Hello world');
+            reject('Hello world');
           }, 1);
         });
       };


### PR DESCRIPTION
This PR 
- updates the `initialize` method to return the response from the callback.
- adds in test cases for error handling to check if the rejected promise and error thrown is bubbled up or not.


Note: The test run will output a warning since we are using Deprecated Domain module.
`(node:88196) [DEP0097] DeprecationWarning: Using a domain property in MakeCallback is deprecated.`. 
